### PR TITLE
Java 8 changes

### DIFF
--- a/puffer/pom.xml
+++ b/puffer/pom.xml
@@ -4,6 +4,18 @@
 	<groupId>com.codeaspect</groupId>
 	<artifactId>puffer</artifactId>
 	<version>1.0</version>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<name>pUFFEr - Object Mapper</name>
 	<description>pUFFEr : A framework to allow conversions between fixed length messages and objects</description>
 	<dependencies>
@@ -51,6 +63,16 @@
 					<show>public</show>
 				</configuration>
 			</plugin>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+					<debug>true</debug>
+				</configuration>
+			</plugin>
+
 		</plugins>
 	</reporting>
 

--- a/puffer/src/main/java/com/codeaspect/puffer/annotations/DiscriminatorValue.java
+++ b/puffer/src/main/java/com/codeaspect/puffer/annotations/DiscriminatorValue.java
@@ -5,7 +5,7 @@
  */
 package com.codeaspect.puffer.annotations;
 
-import com.codeaspect.puffer.packet.AbstractPacket;
+import com.codeaspect.puffer.packet.Packet;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -27,5 +27,5 @@ public @interface DiscriminatorValue {
 	/**
 	 * The target class if any of the values match.
 	 */
-	public Class<? extends AbstractPacket> targetClass();
+	public Class<? extends Packet> targetClass();
 }

--- a/puffer/src/main/java/com/codeaspect/puffer/converters/AbstractPacketConverter.java
+++ b/puffer/src/main/java/com/codeaspect/puffer/converters/AbstractPacketConverter.java
@@ -5,30 +5,30 @@
  */
 package com.codeaspect.puffer.converters;
 
-import com.codeaspect.puffer.packet.AbstractPacket;
+import com.codeaspect.puffer.packet.Packet;
 
 import java.lang.reflect.Field;
 
 /**
- * The Class AbstractPacketConverter is a {@link com.codeaspect.puffer.converters.Converter} for {@link com.codeaspect.puffer.packet.AbstractPacket}<i>s</i><br />.
+ * The Class AbstractPacketConverter is a {@link com.codeaspect.puffer.converters.Converter} for {@link Packet}<i>s</i><br />.
  * The framework does not give any special treatment to Composite Abstract Packets in a mapped entity, hence this converter should be used then mapping a sub-packet.<br />
- * This is the default converter used by the framework when it finds an Object that is an instance of AbstractPacket.
+ * This is the default converter used by the framework when it finds an Object that is an instance of Packet.
  */
-public class AbstractPacketConverter implements SingeltonConverter<AbstractPacket> {
+public class AbstractPacketConverter implements SingeltonConverter<Packet> {
 
 	/* (non-Javadoc)
 	 * @see com.codeaspect.puffer.converters.Converter#hydrate(java.lang.reflect.Field, java.lang.String)
 	 */
-	public AbstractPacket hydrate(Field field, String message) {
+	public Packet hydrate(Field field, String message) {
 		@SuppressWarnings("unchecked")
-		Class<? extends AbstractPacket> clazz = (Class<? extends AbstractPacket>)field.getType();
-		return AbstractPacket.parse(clazz, message);
+		Class<? extends Packet> clazz = (Class<? extends Packet>)field.getType();
+		return Packet.parse(clazz, message);
 	}
 
 	/* (non-Javadoc)
 	 * @see com.codeaspect.puffer.converters.Converter#stringify(java.lang.reflect.Field, java.lang.Object)
 	 */
-	public String stringify(Field field, AbstractPacket message) {
+	public String stringify(Field field, Packet message) {
 		return message.stringify();
 	}
 

--- a/puffer/src/main/java/com/codeaspect/puffer/converters/DefaultConverter.java
+++ b/puffer/src/main/java/com/codeaspect/puffer/converters/DefaultConverter.java
@@ -6,7 +6,7 @@
 package com.codeaspect.puffer.converters;
 
 import com.codeaspect.puffer.exceptions.PufferException;
-import com.codeaspect.puffer.packet.AbstractPacket;
+import com.codeaspect.puffer.packet.Packet;
 
 import java.lang.reflect.Field;
 import java.util.Date;
@@ -28,7 +28,7 @@ public class DefaultConverter implements SingeltonConverter<Object> {
 		converters.put(String.class, new StringConverter());
 		converters.put(Date.class, new AnnotationBasedDateConverter());
 		converters.put(Boolean.class, new BooleanConverter());
-		converters.put(AbstractPacket.class, new AbstractPacketConverter());
+		converters.put(Packet.class, new AbstractPacketConverter());
 	}
 
 	/**
@@ -40,14 +40,14 @@ public class DefaultConverter implements SingeltonConverter<Object> {
 	 */
 	@SuppressWarnings("unchecked")
 	private Converter<Object> getConverter(Class<?> clazz) {
-		Class<?> superClazz = clazz;
-		while (superClazz != null) {
-			if (converters.containsKey(superClazz))
-				return (Converter<Object>) converters.get(superClazz);
-			superClazz = superClazz.getSuperclass();
-		}
-		throw new PufferException(String.format("Unable to convert the field %s, please use a Custom Converter",
-				clazz.getCanonicalName()));
+
+		return converters.entrySet()
+				.stream()
+				.filter(entry->entry.getKey().isAssignableFrom(clazz))
+				.map(Map.Entry::getValue)
+				.map(Converter.class::cast)
+				.findAny()
+				.orElseThrow(()->new PufferException(String.format("Unable to convert the field %s, please use a Custom Converter",  clazz.getCanonicalName())));
 	}
 
 	/*

--- a/puffer/src/main/java/com/codeaspect/puffer/helpers/CacheSettings.java
+++ b/puffer/src/main/java/com/codeaspect/puffer/helpers/CacheSettings.java
@@ -6,7 +6,7 @@
 package com.codeaspect.puffer.helpers;
 
 import com.codeaspect.puffer.cache.Cache;
-import com.codeaspect.puffer.packet.AbstractPacket;
+import com.codeaspect.puffer.packet.Packet;
 
 import java.lang.reflect.Field;
 import java.util.List;
@@ -17,7 +17,7 @@ import java.util.List;
 public class CacheSettings {
 
 	/**
-	 * Sets the field cache used to cache the list of mapped fields in an {@link com.codeaspect.puffer.packet.AbstractPacket}.
+	 * Sets the field cache used to cache the list of mapped fields in an {@link Packet}.
 	 *
 	 * @param fieldCache the field cache
 	 */
@@ -40,7 +40,7 @@ public class CacheSettings {
 	 * @param packetSize the packet size
 	 */
 	public static void setPacketSizeCache(
-			Cache<Class<? extends AbstractPacket>, Integer> packetSize) {
+			Cache<Class<? extends Packet>, Integer> packetSize) {
 		DiscriminatorHelper.setPacketSize(packetSize);
 	}
 }

--- a/puffer/src/main/java/com/codeaspect/puffer/helpers/DiscriminatorHelper.java
+++ b/puffer/src/main/java/com/codeaspect/puffer/helpers/DiscriminatorHelper.java
@@ -7,7 +7,7 @@ import com.codeaspect.puffer.annotations.PacketMessage;
 import com.codeaspect.puffer.cache.Cache;
 import com.codeaspect.puffer.cache.MapCache;
 import com.codeaspect.puffer.exceptions.PufferException;
-import com.codeaspect.puffer.packet.AbstractPacket;
+import com.codeaspect.puffer.packet.Packet;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -17,9 +17,9 @@ public class DiscriminatorHelper {
 
 	private static Cache<String, FieldLocation> discriminatorFieldCache = new MapCache<String, DiscriminatorHelper.FieldLocation>();
 
-	private static Cache<Class<? extends AbstractPacket>, Integer> packetSize = new MapCache<Class<? extends AbstractPacket>, Integer>();
+	private static Cache<Class<? extends Packet>, Integer> packetSize = new MapCache<Class<? extends Packet>, Integer>();
 
-	public static int getPacketLength(Class<? extends AbstractPacket> clazz) {
+	public static int getPacketLength(Class<? extends Packet> clazz) {
 		
 		boolean allowCaching = true;
 		
@@ -53,7 +53,7 @@ public class DiscriminatorHelper {
 		}
 	}
 
-	public static <T extends AbstractPacket> T getConcreteObject(Class<T> clazz, String packet) {
+	public static <T extends Packet> T getConcreteObject(Class<T> clazz, String packet) {
 		try {
 			Class<T> resolvedCalzz = resolveClass(clazz, packet);
 			return resolvedCalzz.newInstance();
@@ -63,7 +63,7 @@ public class DiscriminatorHelper {
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <T extends AbstractPacket> Class<T> resolveClass(Class<T> clazz, String packet) {
+	public static <T extends Packet> Class<T> resolveClass(Class<T> clazz, String packet) {
 		if (clazz.isAnnotationPresent(DiscriminatorField.class)) {
 			DiscriminatorField discFld = clazz.getAnnotation(DiscriminatorField.class);
 
@@ -126,7 +126,7 @@ public class DiscriminatorHelper {
 		DiscriminatorHelper.discriminatorFieldCache = (Cache<String, FieldLocation>) discriminatorFieldCache;
 	}
 
-	static void setPacketSize(Cache<Class<? extends AbstractPacket>, Integer> packetSize) {
+	static void setPacketSize(Cache<Class<? extends Packet>, Integer> packetSize) {
 		DiscriminatorHelper.packetSize = packetSize;
 	}
 

--- a/puffer/src/main/java/com/codeaspect/puffer/helpers/MessageListParser.java
+++ b/puffer/src/main/java/com/codeaspect/puffer/helpers/MessageListParser.java
@@ -3,7 +3,7 @@ package com.codeaspect.puffer.helpers;
 import com.codeaspect.puffer.annotations.PacketList;
 import com.codeaspect.puffer.annotations.PacketMessage;
 import com.codeaspect.puffer.exceptions.PufferException;
-import com.codeaspect.puffer.packet.AbstractPacket;
+import com.codeaspect.puffer.packet.Packet;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.Predicate;
 import org.apache.commons.lang.StringUtils;
@@ -15,13 +15,13 @@ import java.util.List;
 
 public class MessageListParser {
 
-	private AbstractPacket baseObject;
+	private Packet baseObject;
 	private String packet;
 	private List<Field> fields;
 	private ObjectReflection reflection;
 	private volatile int currentLocation;
 
-	public MessageListParser(AbstractPacket baseObject, String packet) {
+	public MessageListParser(Packet baseObject, String packet) {
 		super();
 		this.baseObject = baseObject;
 		this.packet = packet;
@@ -97,7 +97,7 @@ public class MessageListParser {
 	}
 	
 	@SuppressWarnings("unchecked")
-	protected <T extends AbstractPacket> Class<T> getListItemClass(Field fld){
+	protected <T extends Packet> Class<T> getListItemClass(Field fld){
 		try{
 			if(fld.getGenericType() instanceof ParameterizedType){
 				ParameterizedType pt = (ParameterizedType) fld.getGenericType();
@@ -110,7 +110,7 @@ public class MessageListParser {
 		}
 	}
 	
-	public <T extends AbstractPacket> List<T> parseList(Field fld, int start){
+	public <T extends Packet> List<T> parseList(Field fld, int start){
 		synchronized(baseObject){
 			int listSize = findListCount(fld, start);
 			int packetLength = findPacketLength(fld);
@@ -121,7 +121,7 @@ public class MessageListParser {
 			for(int listIndex=0; listIndex<listSize; listIndex++){
 				String packetStringValue = packet.substring(location, location+packetLength);
 				Class<T> listItemClass = getListItemClass(fld);
-				T listItem = AbstractPacket.parse(listItemClass, packetStringValue);
+				T listItem = Packet.parse(listItemClass, packetStringValue);
 				
 				location+=packetLength;
 				lst.add(listItem);

--- a/puffer/src/main/java/com/codeaspect/puffer/packet/AbstractPacket.java
+++ b/puffer/src/main/java/com/codeaspect/puffer/packet/AbstractPacket.java
@@ -1,131 +1,25 @@
+package com.codeaspect.puffer.packet;
+
+import com.codeaspect.puffer.helpers.FieldMetadataHelper;
+import com.codeaspect.puffer.helpers.ObjectReflection;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+import java.lang.reflect.Field;
+
 /*
  * pUFFEr : A framework to allow conversions between fixed length messages and objects
  *
  * @author urvaksh.rogers
  */
-package com.codeaspect.puffer.packet;
+public class AbstractPacket implements Packet {
 
-import com.codeaspect.puffer.annotations.PacketList;
-import com.codeaspect.puffer.annotations.PacketMessage;
-import com.codeaspect.puffer.helpers.*;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
+    /**
+     * Builds a hashCode based on the annotated fields.
+     */
 
-import java.lang.reflect.Field;
-import java.util.List;
-
-public abstract class AbstractPacket {
-
-	/**
-	 * Parses the fixed length packet to the current object based on the
-	 * {@link com.codeaspect.puffer.annotations.PacketMessage} and {@link com.codeaspect.puffer.annotations.PacketList}
-	 * annotations.
-	 * 
-	 * @param <T>
-	 *            the generic type
-	 * @param packet
-	 *            the fixed length String representing the packet
-	 * @param clazz
-	 *            the Class<T> which is the class or a super class of the final packet.
-	 */
-	public <T extends AbstractPacket> void parse(String packet, Class<T> clazz) {
-		List<Field> fields = FieldMetadataHelper.getOrderedFieldList(clazz);
-		MessageListParser listParser = new MessageListParser(this, packet);
-		ObjectReflection reflection = new ObjectReflection(this);
-		int location = 0;
-
-		for (Field fld : fields) {
-			PacketMessage packetMessage = fld.getAnnotation(PacketMessage.class);
-
-			if (fld.isAnnotationPresent(PacketList.class)) {
-				List<? super AbstractPacket> list = listParser.parseList(fld, location);
-				reflection.setFieldValue(fld, list);
-				location=listParser.getCurrentLocation();
-			} else if (AbstractPacket.class.isAssignableFrom(fld.getType())) {
-
-				@SuppressWarnings("unchecked")
-				// Safe cast since the isAssignableFrom check is passed
-				Class<? extends AbstractPacket> fieldClazz = (Class<? extends AbstractPacket>) fld.getType();
-
-				AbstractPacket component = DiscriminatorHelper.getConcreteObject(fieldClazz, packet.substring(location));
-				int packetSize = DiscriminatorHelper.getPacketLength(fieldClazz);
-
-				component.parse(packet.substring(location, location + packetSize));
-				reflection.setFieldValue(fld, component);
-				location += packetSize;
-			} else {
-				String fldStringValue = packet.substring(location, location + packetMessage.length());
-				Object value = ConverterHelper.hydrate(fld, fldStringValue);
-				reflection.setFieldValue(fld, value);
-				location += packetMessage.length();
-			}
-		}
-	}
-
-	/**
-	 * Parses the fixed length packet to the current object based on the
-	 * {@link com.codeaspect.puffer.annotations.PacketMessage} and {@link com.codeaspect.puffer.annotations.PacketList}
-	 * annotations.
-	 * 
-	 * @param packet
-	 *            the fixed length String representing the packet
-	 */
-	public void parse(String packet) {
-		parse(packet, getClass());
-	}
-
-	/**
-	 * Parses the fixed length packet to the specified class or it's subclasses based on the specified
-	 * {@link com.codeaspect.puffer.annotations.DiscriminatorField} and the
-	 * {@link com.codeaspect.puffer.annotations.PacketMessage} and {@link com.codeaspect.puffer.annotations.PacketList}
-	 * of the destination class annotations.
-	 * 
-	 * @param <T>
-	 *            the generic type
-	 * @param clazz
-	 *            the target class - can be a base class if {@link com.codeaspect.puffer.annotations.DiscriminatorField}
-	 *            is specified, the target class will automatically be looked up.
-	 * @param packet
-	 *            the fixed length String representing the packet
-	 * @return the parsed Object
-	 */
-	public static <T extends AbstractPacket> T parse(Class<T> clazz, String packet) {
-		T obj = DiscriminatorHelper.getConcreteObject(clazz, packet);
-		obj.parse(packet);
-		return obj;
-	}
-
-	/**
-	 * The fixed length string created from the object based on the
-	 * {@link com.codeaspect.puffer.annotations.PacketMessage} and {@link com.codeaspect.puffer.annotations.PacketList}
-	 * annotations
-	 */
-	
-	public String stringify() {
-		StringBuilder packetBuilder = new StringBuilder();
-		ObjectReflection reflection = new ObjectReflection(this);
-
-		for (Field fld : FieldMetadataHelper.getOrderedFieldList(getClass())) {
-			if (fld.isAnnotationPresent(PacketList.class)) {
-				List<?> list = (List<?>) reflection.getFieldValue(fld);
-				for (Object obj : list) {
-					packetBuilder.append(obj.toString());
-				}
-			} else {
-				Object value = reflection.getFieldValue(fld);
-				String stringValue = ConverterHelper.stringifyAndPad(fld, value);
-				packetBuilder.append(stringValue);
-			}
-		}
-
-		return packetBuilder.toString();
-	}
-
-	/**
-	 * Builds a hashCode based on the annotated fields.
-	 */
 	@Override
-	public int hashCode() {
+	public  int hashCode() {
 		ObjectReflection reflection = new ObjectReflection(this);
 		HashCodeBuilder hashCodeBuilder = new HashCodeBuilder();
 
@@ -136,10 +30,12 @@ public abstract class AbstractPacket {
 		return hashCodeBuilder.toHashCode();
 	}
 
-	/**
-	 * If the objects are of the same class equals performs a field by field comparison (only of annotated fields) to
-	 * dertimine equality.
-	 */
+
+    /**
+     * If the objects are of the same class equals performs a field by field comparison (only of annotated fields) to
+     * dertimine equality.
+     */
+
 	@Override
 	public boolean equals(Object obj) {
 		if (this == obj)

--- a/puffer/src/main/java/com/codeaspect/puffer/packet/Packet.java
+++ b/puffer/src/main/java/com/codeaspect/puffer/packet/Packet.java
@@ -1,0 +1,123 @@
+/*
+ * pUFFEr : A framework to allow conversions between fixed length messages and objects
+ *
+ * @author urvaksh.rogers
+ */
+package com.codeaspect.puffer.packet;
+
+import com.codeaspect.puffer.annotations.PacketList;
+import com.codeaspect.puffer.annotations.PacketMessage;
+import com.codeaspect.puffer.helpers.*;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+public interface Packet {
+
+	/**
+	 * Parses the fixed length packet to the current object based on the
+	 * {@link com.codeaspect.puffer.annotations.PacketMessage} and {@link com.codeaspect.puffer.annotations.PacketList}
+	 * annotations.
+	 * 
+	 * @param <T>
+	 *            the generic type
+	 * @param packet
+	 *            the fixed length String representing the packet
+	 * @param clazz
+	 *            the Class<T> which is the class or a super class of the final packet.
+	 */
+	public default  <T extends Packet> void parse(String packet, Class<T> clazz) {
+		List<Field> fields = FieldMetadataHelper.getOrderedFieldList(clazz);
+		MessageListParser listParser = new MessageListParser(this, packet);
+		ObjectReflection reflection = new ObjectReflection(this);
+		int location = 0;
+
+		for (Field fld : fields) {
+			PacketMessage packetMessage = fld.getAnnotation(PacketMessage.class);
+
+			if (fld.isAnnotationPresent(PacketList.class)) {
+				List<? super Packet> list = listParser.parseList(fld, location);
+				reflection.setFieldValue(fld, list);
+				location=listParser.getCurrentLocation();
+			} else if (Packet.class.isAssignableFrom(fld.getType())) {
+
+				@SuppressWarnings("unchecked")
+				// Safe cast since the isAssignableFrom check is passed
+				Class<? extends Packet> fieldClazz = (Class<? extends Packet>) fld.getType();
+
+				Packet component = DiscriminatorHelper.getConcreteObject(fieldClazz, packet.substring(location));
+				int packetSize = DiscriminatorHelper.getPacketLength(fieldClazz);
+
+				component.parse(packet.substring(location, location + packetSize));
+				reflection.setFieldValue(fld, component);
+				location += packetSize;
+			} else {
+				String fldStringValue = packet.substring(location, location + packetMessage.length());
+				Object value = ConverterHelper.hydrate(fld, fldStringValue);
+				reflection.setFieldValue(fld, value);
+				location += packetMessage.length();
+			}
+		}
+	}
+
+	/**
+	 * Parses the fixed length packet to the current object based on the
+	 * {@link com.codeaspect.puffer.annotations.PacketMessage} and {@link com.codeaspect.puffer.annotations.PacketList}
+	 * annotations.
+	 * 
+	 * @param packet
+	 *            the fixed length String representing the packet
+	 */
+	public default void parse(String packet) {
+		parse(packet, getClass());
+	}
+
+	/**
+	 * Parses the fixed length packet to the specified class or it's subclasses based on the specified
+	 * {@link com.codeaspect.puffer.annotations.DiscriminatorField} and the
+	 * {@link com.codeaspect.puffer.annotations.PacketMessage} and {@link com.codeaspect.puffer.annotations.PacketList}
+	 * of the destination class annotations.
+	 * 
+	 * @param <T>
+	 *            the generic type
+	 * @param clazz
+	 *            the target class - can be a base class if {@link com.codeaspect.puffer.annotations.DiscriminatorField}
+	 *            is specified, the target class will automatically be looked up.
+	 * @param packet
+	 *            the fixed length String representing the packet
+	 * @return the parsed Object
+	 */
+	public static <T extends Packet> T parse(Class<T> clazz, String packet) {
+		T obj = DiscriminatorHelper.getConcreteObject(clazz, packet);
+		obj.parse(packet);
+		return obj;
+	}
+
+	/**
+	 * The fixed length string created from the object based on the
+	 * {@link com.codeaspect.puffer.annotations.PacketMessage} and {@link com.codeaspect.puffer.annotations.PacketList}
+	 * annotations
+	 */
+	
+	public default String stringify() {
+		StringBuilder packetBuilder = new StringBuilder();
+		ObjectReflection reflection = new ObjectReflection(this);
+
+		for (Field fld : FieldMetadataHelper.getOrderedFieldList(getClass())) {
+			if (fld.isAnnotationPresent(PacketList.class)) {
+				List<?> list = (List<?>) reflection.getFieldValue(fld);
+				for (Object obj : list) {
+					packetBuilder.append(obj.toString());
+				}
+			} else {
+				Object value = reflection.getFieldValue(fld);
+				String stringValue = ConverterHelper.stringifyAndPad(fld, value);
+				packetBuilder.append(stringValue);
+			}
+		}
+
+		return packetBuilder.toString();
+	}
+
+
+}

--- a/puffer/src/test/java/com/codeaspect/puffer/converters/AnnotationBasedDateConverterTest.java
+++ b/puffer/src/test/java/com/codeaspect/puffer/converters/AnnotationBasedDateConverterTest.java
@@ -2,7 +2,7 @@ package com.codeaspect.puffer.converters;
 
 import com.codeaspect.puffer.annotations.PacketMessage;
 import com.codeaspect.puffer.annotations.TemporalFormat;
-import com.codeaspect.puffer.packet.AbstractPacket;
+import com.codeaspect.puffer.packet.Packet;
 import com.codeaspect.puffer.testutils.TestUtils;
 import junit.framework.Assert;
 import org.junit.Ignore;
@@ -14,7 +14,7 @@ import java.util.Date;
 public class AnnotationBasedDateConverterTest {
 	
 	@Ignore
-	public static class TestPacket extends AbstractPacket {
+	public static class TestPacket implements Packet {
 		@PacketMessage(position=1, length=7)
 		@TemporalFormat("dd-MM-yyyy")
 		public Date date;

--- a/puffer/src/test/java/com/codeaspect/puffer/converters/BooleanConverterTest.java
+++ b/puffer/src/test/java/com/codeaspect/puffer/converters/BooleanConverterTest.java
@@ -2,7 +2,7 @@ package com.codeaspect.puffer.converters;
 
 import com.codeaspect.puffer.annotations.BooleanFormat;
 import com.codeaspect.puffer.annotations.PacketMessage;
-import com.codeaspect.puffer.packet.AbstractPacket;
+import com.codeaspect.puffer.packet.Packet;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -13,7 +13,7 @@ import static junit.framework.Assert.assertEquals;
 public class BooleanConverterTest {
 	
 	@Ignore
-	public static class TestPacket extends AbstractPacket {
+	public static class TestPacket implements Packet {
 		@PacketMessage(position=1, length=1)
 		@BooleanFormat(defaultValue=false, trueValue="Y", falseValue="N")
 		public Boolean bool;

--- a/puffer/src/test/java/com/codeaspect/puffer/converters/PacketConverterTest.java
+++ b/puffer/src/test/java/com/codeaspect/puffer/converters/PacketConverterTest.java
@@ -2,17 +2,17 @@ package com.codeaspect.puffer.converters;
 
 import com.codeaspect.puffer.annotations.PacketMessage;
 import com.codeaspect.puffer.enums.Side;
-import com.codeaspect.puffer.packet.AbstractPacket;
+import com.codeaspect.puffer.packet.Packet;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
 
-public class AbstractPacketConverterTest {
+public class PacketConverterTest {
 	
 	@Ignore
-	public static class TestPacket extends AbstractPacket {
+	public static class TestPacket implements Packet {
 		@PacketMessage(position=1, length=7)
 		public String field1;
 		
@@ -21,7 +21,7 @@ public class AbstractPacketConverterTest {
 	};
 	
 	@Ignore
-	public static class TestOuterPacket extends AbstractPacket {
+	public static class TestOuterPacket implements Packet {
 		@PacketMessage(position=1, length=7)
 		public TestPacket packet;
 	};

--- a/puffer/src/test/java/com/codeaspect/puffer/packet/ComponentMappingTest.java
+++ b/puffer/src/test/java/com/codeaspect/puffer/packet/ComponentMappingTest.java
@@ -7,7 +7,7 @@ import static junit.framework.Assert.assertEquals;
 
 public class ComponentMappingTest {
 	
-	public static class Message extends AbstractPacket {
+	public static class Message implements Packet {
 
 		@PacketMessage(length = 10, position = 1)
 		String details;
@@ -16,7 +16,7 @@ public class ComponentMappingTest {
 		InnerMessage messages;
 	}
 
-	public static class InnerMessage extends AbstractPacket {
+	public static class InnerMessage implements Packet {
 
 		@PacketMessage(length = 1, position = 1)
 		private String identifier;
@@ -27,7 +27,7 @@ public class ComponentMappingTest {
 	
 	@Test
 	public void testMapping() {
-		Message msg = AbstractPacket.parse(Message.class, "0123456789AXXXXX");
+		Message msg = Packet.parse(Message.class, "0123456789AXXXXX");
 		assertEquals("0123456789", msg.details);
 		assertEquals("A", msg.messages.identifier);
 		assertEquals("XXXXX", msg.messages.name);

--- a/puffer/src/test/java/com/codeaspect/puffer/packet/DiscriminatorPacketTest.java
+++ b/puffer/src/test/java/com/codeaspect/puffer/packet/DiscriminatorPacketTest.java
@@ -17,15 +17,15 @@ public class DiscriminatorPacketTest {
 	static{
 		CacheSettings.setFieldCache(MapFieldCache.getInstance());
 		CacheSettings.setDiscriminatorFieldCache(new MapCache<String, Object>());
-		CacheSettings.setPacketSizeCache(new MapCache<Class<? extends AbstractPacket>, Integer>());
+		CacheSettings.setPacketSizeCache(new MapCache<Class<? extends Packet>, Integer>());
 	}
 
 	@Ignore
-	@Packet(description = "Packet to test Discriminators")
+	@com.codeaspect.puffer.annotations.Packet(description = "Packet to test Discriminators")
 	@DiscriminatorField(fieldName = "fld1", 
 		values = { @DiscriminatorValue(fieldValues = {"ABC", "abc" }, targetClass = Derived1.class),
 					@DiscriminatorValue(fieldValues = {"XYZ", "xyz" }, targetClass = Middle.class)})
-	public static abstract class Base extends AbstractPacket {
+	public static abstract class Base implements Packet {
 		@PacketMessage(length = 4, position = 1)
 		String dummy;
 
@@ -86,7 +86,7 @@ public class DiscriminatorPacketTest {
 	@Test
 	public void testDerived1(){
 		String input = "----ABCY2014-08-15";
-		AbstractPacket packet= AbstractPacket.parse(Base.class, input);
+		Packet packet= Packet.parse(Base.class, input);
 		
 		assertEquals(Derived1.class, packet.getClass());
 		
@@ -102,7 +102,7 @@ public class DiscriminatorPacketTest {
 	@Test
 	public void testRederived(){
 		String input = "----xyzNABC00500";
-		AbstractPacket packet= AbstractPacket.parse(Base.class, input);
+		Packet packet= Packet.parse(Base.class, input);
 		
 		assertEquals(ReDerived.class, packet.getClass());
 		
@@ -119,7 +119,7 @@ public class DiscriminatorPacketTest {
 	@Test
 	public void testRederived2(){
 		String input = "----xyzNXYZFive Hundred   ";
-		AbstractPacket packet= AbstractPacket.parse(Base.class, input);
+		Packet packet= Packet.parse(Base.class, input);
 		
 		assertEquals(ReDerived2.class, packet.getClass());
 		

--- a/puffer/src/test/java/com/codeaspect/puffer/packet/ListMappingTest.java
+++ b/puffer/src/test/java/com/codeaspect/puffer/packet/ListMappingTest.java
@@ -10,7 +10,7 @@ import static junit.framework.Assert.assertEquals;
 
 public class ListMappingTest {
 
-	public static class Message extends AbstractPacket {
+	public static class Message implements Packet {
 
 		@PacketMessage(length = 10, position = 1)
 		String details;
@@ -20,7 +20,7 @@ public class ListMappingTest {
 		List<InnerMessage> messages;
 	}
 
-	public static class InnerMessage extends AbstractPacket {
+	public static class InnerMessage implements Packet {
 
 		@PacketMessage(length = 1, position = 1)
 		private String identifier;
@@ -31,7 +31,7 @@ public class ListMappingTest {
 
 	@Test
 	public void testMapping() {
-		Message msg = AbstractPacket.parse(Message.class, "0123456789AXXXXXBYYYYY");
+		Message msg = Packet.parse(Message.class, "0123456789AXXXXXBYYYYY");
 		assertEquals("0123456789", msg.details);
 		assertEquals(2, msg.messages.size());
 		assertEquals("A", msg.messages.get(0).identifier);

--- a/puffer/src/test/java/com/codeaspect/puffer/packet/SimplePacketTest.java
+++ b/puffer/src/test/java/com/codeaspect/puffer/packet/SimplePacketTest.java
@@ -13,7 +13,7 @@ import static junit.framework.Assert.*;
 public class SimplePacketTest {
 
 	@Ignore
-	public static class OrderDetail extends AbstractPacket {
+	public static class OrderDetail implements Packet {
 
 		@PacketMessage(position = 1, length = 10)
 		private String name;
@@ -29,7 +29,7 @@ public class SimplePacketTest {
 	@Test
 	public void testMapping(){
 		String message = "Item1     1508201300100";
-		OrderDetail detail = AbstractPacket.parse(OrderDetail.class, message);
+		OrderDetail detail = Packet.parse(OrderDetail.class, message);
 		assertEquals("Item1", detail.name.trim());
 		assertEquals(TestUtils.createDate(15, 8, 2013), detail.date);
 		assertEquals(new Long(100), detail.amount);


### PR DESCRIPTION
Changed pom to compile with Java8.
Updated approach has Packet as an interface with default methods so classes only have to implement Packet not extend AbstractPacket as was previously the case.